### PR TITLE
added package.json for npm package publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "memoryjs",
+  "version": "1.0.0",
+  "description": "memoryJS is a dependecy free, ES6 compliant JS library that implements the concept of pointers in JavaScript",
+  "main": "memory.min.js",
+  "files": [
+    "memory.min.js",
+    "memory.secret.min.js"
+  ],
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "standard memory.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unsuitable001/memoryJS.git"
+  },
+  "keywords": [
+    "memoryjs"
+  ],
+  "author": "unsuitable001",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/unsuitable001/memoryJS/issues"
+  },
+  "homepage": "https://github.com/unsuitable001/memoryJS#readme"
+}


### PR DESCRIPTION
This will get you started in the right direction to taking this and turning it into an NPM package, issue #1 . I've added the package.json file which is used by NPM to create the package. To actually publish the package, all you will have to do is run, `npm publish`, while you are inside the folder.

Some things to look at before publishing. In package.json, you have name, version, author, and description that you can edit with what you would like. I've added main and files as well into the JSON. Main tells NPM that memory.min.js will be the entry point into your package when someone references it by the package name. Files is there to tell NPM which files it should publish to the package. I added the two minified files, but can be updated to include the non-minified version as well. 

One other thing that can be done is referencing a file directly once the package is installed like so, 
```
const memoryJS = require('../node_modules/memory.min.js');
```
That is a pretty common way to reference pure JS files that were packaged to be used inside NodeJS or something like React or Angular. I hope this helps!